### PR TITLE
README: Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,25 @@ Install
 
 Download the binary package from [Releases](https://github.com/hymkor/binview/releases) and extract the executable.
 
-### Use "go install"
+<!-- pwsh -Command "readme-install.ps1" | -->
+
+### Use [eget] installer (cross-platform)
+
+```sh
+brew install eget        # Unix-like systems
+# or
+scoop install eget       # Windows
+
+cd (YOUR-BIN-DIRECTORY)
+eget hymkor/binview
+```
+
+[eget]: https://github.com/zyedidia/eget
+
+### Use [scoop]-installer (Windows only)
 
 ```
-go install github.com/hymkor/binview@latest
-```
-
-### Use scoop-installer
-
-```
-scoop install https://raw.githubusercontent.com/hymkor/binview/master/bine.json
+scoop install https://raw.githubusercontent.com/hymkor/binview/master/binview.json
 ```
 
 or
@@ -53,6 +62,17 @@ or
 scoop bucket add hymkor https://github.com/hymkor/scoop-bucket
 scoop install binview
 ```
+
+[scoop]: https://scoop.sh/
+
+### Use "go install" (requires Go toolchain)
+
+```
+go install github.com/hymkor/binview@latest
+```
+
+Because `go install` introduces the executable into `$HOME/go/bin` or `$GOPATH/bin`, you need to add this directory to your `$PATH` to execute `binview`.
+<!-- -->
 
 Usage
 -----


### PR DESCRIPTION
(English)

- Improve the installation section
  - Since `eget` is currently the easiest option for macOS and Linux users, its usage is now described first, starting from how to install `eget` via Homebrew or Scoop.
  - The `go install` instructions were moved to the end because they may require installing the full Go toolchain.

(Japanese)

- インストールセクションを改善
  - macOS / Linux ユーザにとっては今のところ eget が一番手軽なため、eget の説明を先頭へ移動。homebrew/scoop で eget を入れるところから手順を提示
  - `go install` の説明は、Go言語一式のインストールまで要求してしまう場合があるため、最後へ移動
