### PR TITLE
Improved Escape key handling using `go-ttyadapter/tty8pe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ Key-binding
     * Write changes to file
 * `&`  
     * Jump to a specific address
-* `ALT-U`  
+* `ALT-U`, `Esc-U`  
     * Change the character encoding to UTF-8 (default)
-* `ALT-A`  
+* `ALT-A`, `Esc-A`  
     * Change the character encoding to ANSI (the current Windows code page)
-* `ALT-L`  
+* `ALT-L`, `Esc-L`  
     * Change the character encoding to UTF-16LE
-* `ALT-B`  
+* `ALT-B`, `Esc-B`  
     * Change the character encoding to UTF-16BE
 
 Release Notes

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/nyaosorg/go-inline-animation v0.3.0
 	github.com/nyaosorg/go-readline-ny v1.13.0
-	github.com/nyaosorg/go-ttyadapter v0.1.0
+	github.com/nyaosorg/go-ttyadapter v0.3.0
 	github.com/nyaosorg/go-windows-mbcs v0.4.4
 	golang.org/x/sys v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/nyaosorg/go-inline-animation v0.3.0 h1:LrOHowED2PrXEUWGagL1bLR+XTXD06
 github.com/nyaosorg/go-inline-animation v0.3.0/go.mod h1:GLb7BXeLMuA12LMN3c8l69GQcmlAxit3oZRKILztOsU=
 github.com/nyaosorg/go-readline-ny v1.13.0 h1:3ifu0FQsswdB9N5vcph7lVzQvu20kVt6pMt1JuSz45o=
 github.com/nyaosorg/go-readline-ny v1.13.0/go.mod h1:pFXLTklUi8JVi6gI3HdnA3Wak/7cl+kx2q8kIIiAf/c=
-github.com/nyaosorg/go-ttyadapter v0.1.0 h1:3U3ytc35SOdkrn15rHLG36ozkmqBeGqhQgNufoep1AI=
-github.com/nyaosorg/go-ttyadapter v0.1.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
+github.com/nyaosorg/go-ttyadapter v0.3.0 h1:/Y7+rGJ0LEcs+AExevwNmND2VJvvpBmgbMuCbntKq3c=
+github.com/nyaosorg/go-ttyadapter v0.3.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 github.com/nyaosorg/go-windows-mbcs v0.4.4 h1:x5MqDvOsfRO8F2a9Uedlm3I6SB/H0whN4KZknTOLe3w=
 github.com/nyaosorg/go-windows-mbcs v0.4.4/go.mod h1:P610Wyc6LcgDbx2VZhwUQn02XRuwjqGK2l/3wox3auA=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -370,17 +370,7 @@ func keyFuncUndo(app *Application) error {
 	return nil
 }
 
-func keyPending(s string) func(app *Application) error {
-	return func(app *Application) error {
-		app.pendingEscape = s
-		app.message = fmt.Sprintf("%#v", s)
-		return nil
-	}
-}
-
 var jumpTable = map[string]func(this *Application) error{
-	"\x1B":      keyPending("\x1B"),
-	"\x1B[":     keyPending("\x1B["),
 	"u":         keyFuncUndo,
 	"i":         keyFuncInsertExp,
 	"a":         keyFuncAppendExp,

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattn/go-runewidth"
 
 	"github.com/nyaosorg/go-ttyadapter"
-	"github.com/nyaosorg/go-ttyadapter/tty8"
+	"github.com/nyaosorg/go-ttyadapter/tty8pe"
 
 	"github.com/hymkor/binview/internal/argf"
 	"github.com/hymkor/binview/internal/encoding"
@@ -211,10 +211,6 @@ type Application struct {
 	cache        map[int]string
 	encoding     encoding.Encoding
 	undoFuncs    []func(app *Application)
-
-	// Some terminals may split escape sequences (e.g. ESC + '[' + 'D').
-	// To avoid misinterpreting partial input, we buffer prefix keys here.
-	pendingEscape string
 }
 
 func (app *Application) dataHeight() int {
@@ -350,7 +346,7 @@ func Run(args []string) error {
 		}
 	}
 
-	app, err := NewApplication(&tty8.Tty{}, in, out, savePath)
+	app, err := NewApplication(&tty8pe.Tty{}, in, out, savePath)
 	if err != nil {
 		return err
 	}
@@ -362,13 +358,7 @@ func Run(args []string) error {
 	//
 	// Therefore, all reads are centralized in keyWorker, and this goroutine
 	// accesses data only via keyWorker.Fetch / TryFetch.
-
-	keyWorker := nonblock.New(func() (string, error) {
-		ch, err := app.tty1.GetKey()
-		ch = app.pendingEscape + ch
-		app.pendingEscape = ""
-		return ch, err
-	}, app.buffer.Fetch)
+	keyWorker := nonblock.New(app.tty1.GetKey, app.buffer.Fetch)
 	defer keyWorker.Close()
 	app.buffer.Fetch = keyWorker.Fetch
 	app.buffer.TryFetch = func() ([]byte, error) {


### PR DESCRIPTION
- Update go-ttyadapter to v0.3.0
- Improved Escape key handling using `go-ttyadapter/tty8pe`
- README: Add `Esc-U`, `Esc-A`, `Esc-L` and `Esc-B`