### PR TITLE
Improved build portability by replacing local helper tools with 'go run' (make release, make manifest).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ clean:
 	$(DEL) *.zip $(NAME)$(EXE)
 
 manifest:
-	make-scoop-manifest -all *-windows-*.zip > $(NAME).json
+	$(GO) run github.com/hymkor/make-scoop-manifest@master -all *-windows-*.zip > $(NAME).json
 
 .PHONY: all test _dist dist clean manifest

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ EXE=$(shell $(GO) env GOEXE)
 
 all:
 	$(GO) fmt ./...
-	$(SET) "CGO_ENABLED=0" && $(GO) build $(GOOPT) && $(GO) build -C cmd/bine $(GOOPT) -o $(CURDIR)
+	$(SET) "CGO_ENABLED=0" && $(GO) build -C cmd/bine $(GOOPT) -o $(CURDIR)
 
 test:
 	$(GO) test -v

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ dist:
 	$(SET) "GOOS=windows" && $(SET) "GOARCH=amd64" && $(MAKE) _dist
 
 release:
-	pwsh -Command "latest-notes.ps1" | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+	$(GO) run github.com/hymkor/latest-notes@master | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 clean:
 	$(DEL) *.zip $(NAME)$(EXE)

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -1,6 +1,8 @@
 Release notes
 =============
 
+- Improved build portability by replacing local helper tools with 'go run' (make release, make manifest). (#28)
+
 v0.7.0
 ------
 Feb 6, 2026

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -1,6 +1,8 @@
 Release notes
 =============
 
+- go run の活用により、外部ツール不要でビルド・メンテナンスができるよう改善した (`make release`, `make manifest`) (#28)
+
 v0.7.0
 ------
 Feb 6, 2026


### PR DESCRIPTION
(English)
- Improved build portability by replacing local helper tools with `go run` (`make release`, `make manifest`).

(Japanese)
- `go run` の活用により、外部ツール不要でビルド・メンテナンスができるよう改善した (`make release`, `make manifest`)