### PR TITLE
Update nyaosorg/go-inline-animation to version 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
   The version string is now updated via `make bump` during the release process. (#33)
 - Rename release note files to CHANGELOG.md and CHANGELOG\_ja.md. (#34)
 - Changed file saving to use a temporary file until writing completes, eliminating any window where the original file could be left in a partial state. (#35)
+- Fixed an issue where the progress animation was cleared at the wrong position during long save operations. ([go-inline-animation#6], [go-inline-animation#7], #36)
+
+[go-inline-animation#6]: https://github.com/nyaosorg/go-inline-animation/pull/6
+[go-inline-animation#7]: https://github.com/nyaosorg/go-inline-animation/pull/7
 
 v0.7.1
 ------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -5,6 +5,10 @@ Changelog
   今後、バージョンアップ時に `make bump` を実行する (#33)
 - リリースノートのファイル名を CHANGELOG.md と CHANGELOG\_JA.md へリネーム (#34)
 - ファイル保存時に出力が完了するまで一時ファイル名を使い、元のファイルが不完全な状態になる時間をゼロとした (#35)
+- 保存に時間がかかった時、テキストアニメの消去位置が狂う問題を修正 ([go-inline-animation#6], [go-inline-animation#7], #36)
+
+[go-inline-animation#6]: https://github.com/nyaosorg/go-inline-animation/pull/6
+[go-inline-animation#7]: https://github.com/nyaosorg/go-inline-animation/pull/7
 
 v0.7.1
 ------

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.19
-	github.com/nyaosorg/go-inline-animation v0.3.0
+	github.com/nyaosorg/go-inline-animation v0.3.1
 	github.com/nyaosorg/go-readline-ny v1.14.1
 	github.com/nyaosorg/go-ttyadapter v0.3.0
 	github.com/nyaosorg/go-windows-mbcs v0.4.4

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byF
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
 github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
-github.com/nyaosorg/go-inline-animation v0.3.0 h1:LrOHowED2PrXEUWGagL1bLR+XTXD06EoWnLRAAn0PWc=
-github.com/nyaosorg/go-inline-animation v0.3.0/go.mod h1:GLb7BXeLMuA12LMN3c8l69GQcmlAxit3oZRKILztOsU=
+github.com/nyaosorg/go-inline-animation v0.3.1 h1:AXjYkjyK4AEXXDNGQ8yd1RFY4aCKf7b9/cH6CcVHPps=
+github.com/nyaosorg/go-inline-animation v0.3.1/go.mod h1:GLb7BXeLMuA12LMN3c8l69GQcmlAxit3oZRKILztOsU=
 github.com/nyaosorg/go-readline-ny v1.14.1 h1:bWyXpR6jRaCXysx4bnioxk36+YjQ6dypHKMjHnzIXdk=
 github.com/nyaosorg/go-readline-ny v1.14.1/go.mod h1:/BDf3/H/AScnvey4LoDws1bjTZDB76EE7uKnW2apoKU=
 github.com/nyaosorg/go-ttyadapter v0.3.0 h1:/Y7+rGJ0LEcs+AExevwNmND2VJvvpBmgbMuCbntKq3c=


### PR DESCRIPTION
(English)
- Fixed an issue where the progress animation was cleared at the wrong position during long save operations. 

(Japanese)
- 保存に時間がかかった時、テキストアニメの消去位置が狂う問題を修正
 
See also [go-inline-animation#6], [go-inline-animation#7]

[go-inline-animation#6]: https://github.com/nyaosorg/go-inline-animation/pull/6
[go-inline-animation#7]: https://github.com/nyaosorg/go-inline-animation/pull/7