### PR TITLE
Improve error message when backup fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hymkor/bine
 go 1.20
 
 require (
-	github.com/hymkor/go-safewrite v0.1.0
+	github.com/hymkor/go-safewrite v0.2.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/nyaosorg/go-inline-animation v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
 github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/hymkor/go-safewrite v0.1.0 h1:M3W24Hw7TaepjCl4se/LE6Jj0rAl55TafM15XAMfeIg=
-github.com/hymkor/go-safewrite v0.1.0/go.mod h1:UiLRe1/Al1kAkJJK65+xAFMhiacBwK6oEVHsu9+n4fo=
+github.com/hymkor/go-safewrite v0.2.0 h1:VGy8s1vMUVOphKdznK+KI/1TgEETVr8vb06l1hBV38I=
+github.com/hymkor/go-safewrite v0.2.0/go.mod h1:UiLRe1/Al1kAkJJK65+xAFMhiacBwK6oEVHsu9+n4fo=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/nyaosorg/go-inline-animation"
@@ -214,6 +215,14 @@ func writeFile(buffer *large.Buffer, tty1 Tty, out io.Writer, fname string) (str
 		return "", err1
 	}
 	if err2 != nil {
+		var e *safewrite.BackupError
+		if errors.As(err2, &e) {
+			return "",
+				fmt.Errorf("Failed to backup %q to %q (tmp: %q)",
+					filepath.Base(e.Target),
+					filepath.Base(e.Backup),
+					filepath.Base(e.Tmp))
+		}
 		return "", err2
 	}
 	fnameHistory.Add(fname)


### PR DESCRIPTION
e.g.

```go
fmt.Errorf("Failed to backup %q to %q (tmp: %q)",
                filepath.Base(e.Target),
                filepath.Base(e.Backup),
                filepath.Base(e.Tmp))
```