### PR TITLE
Change file permission only when shutdown application

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hymkor/bine
 go 1.20
 
 require (
-	github.com/hymkor/go-safewrite v0.2.0
+	github.com/hymkor/go-safewrite v0.3.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/nyaosorg/go-inline-animation v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
 github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/hymkor/go-safewrite v0.2.0 h1:VGy8s1vMUVOphKdznK+KI/1TgEETVr8vb06l1hBV38I=
-github.com/hymkor/go-safewrite v0.2.0/go.mod h1:UiLRe1/Al1kAkJJK65+xAFMhiacBwK6oEVHsu9+n4fo=
+github.com/hymkor/go-safewrite v0.3.0 h1:+XlKrRnqW9PmYtCUWPb3rKxvAsM/PU7IkEn7Lgi7U0U=
+github.com/hymkor/go-safewrite v0.3.0/go.mod h1:UiLRe1/Al1kAkJJK65+xAFMhiacBwK6oEVHsu9+n4fo=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -67,7 +67,7 @@ func keyFuncQuit(this *Application) error {
 			return err
 		}
 		if ch == "y" || ch == "Y" {
-			newfname, err := writeFile(this.buffer, this.tty1, this.out, this.savePath)
+			newfname, err := writeFile(this)
 			if err != nil {
 				this.message = err.Error()
 				return nil
@@ -186,7 +186,12 @@ func getlineOr(out io.Writer, prompt string, defaultString string, history readl
 
 var fnameHistory = simplehistory.New()
 
-func writeFile(buffer *large.Buffer, tty1 Tty, out io.Writer, fname string) (string, error) {
+func writeFile(app *Application) (string, error) {
+	buffer := app.buffer
+	tty1 := app.tty1
+	out := app.out
+	fname := app.savePath
+
 	var err error
 	fname, err = getlineOr(out, "write to>", fname, fnameHistory)
 	if err != nil {
@@ -237,7 +242,7 @@ func writeFile(buffer *large.Buffer, tty1 Tty, out io.Writer, fname string) (str
 }
 
 func keyFuncWriteFile(this *Application) error {
-	newfname, err := writeFile(this.buffer, this.tty1, this.out, this.savePath)
+	newfname, err := writeFile(this)
 	if err != nil {
 		this.message = err.Error()
 	} else {

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -238,6 +238,9 @@ func writeFile(app *Application) (string, error) {
 		return "", err2
 	}
 	fnameHistory.Add(fname)
+	app.registerOnClose(fname, func() {
+		safewrite.RestorePerm(fd)
+	})
 	return fname, nil
 }
 


### PR DESCRIPTION
(English)
- Restoring the new file’s permissions to match the original file is now performed at application shutdown.
  Doing this during each save could prevent subsequent saves, because the application itself may have made the file read-only.  
  *(Note: since permission restoration was not included in any released version, this change is not mentioned in the CHANGELOG.)*

(Japanese)
- 新ファイルのパーミッションを旧ファイルと同じように変更するのは、アプリケーションが終了するタイミングで行うようにした。さもないと、二回目以降にセーブする時、自分で行ったパーミッション変更で、上書き保存ができなくなってしまうため  
*（ただし、パーミッションの復元処理がそもそもリリースされたバージョンには含まれていないので、本件は CHANGELOG には記載しないものとする）*