### PR TITLE
Do not ask whether overwrite or not for same files

### DIFF
--- a/keyfunc.go
+++ b/keyfunc.go
@@ -198,6 +198,9 @@ func writeFile(app *Application) (string, error) {
 		return "", err
 	}
 	prompt := func(info *safewrite.Info) bool {
+		if info.Status != safewrite.NONE {
+			return true
+		}
 		if info.ReadOnly() {
 			if yesNo(tty1, out, "Overwrite READONLY file \""+info.Name+"\" [y/n] ?") {
 				return true


### PR DESCRIPTION
*(English)*
- Once a file has been confirmed and overwritten, the application no longer asks for overwrite confirmation on subsequent saves.
  (Since repeated confirmation was not part of any released version, this behavior is not mentioned in the CHANGELOG.)

*(Japanese)*
- 一度上書き保存したファイルについては、再び上書き確認しないようにした。  
  （再度確認する動作はリリースバージョンには含まれていないので、本動作は CHANGELOG には記載しないものとする）