### PR TITLE
Add Edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 Changelog
-=============
+=========
 
 - Fixed an issue where the version string was empty when built without GNU Make.  
   The version string is now updated via `make bump` during the release process. (#33)
@@ -8,6 +8,7 @@ Changelog
 - Fixed an issue where the progress animation was cleared at the wrong position during long save operations. ([go-inline-animation#6], [go-inline-animation#7], #36)
 - Indicate READONLY files explicitly when prompting for overwrite confirmation (#37)
 - Preserve original file permissions when overwriting files (#37,#42)
+- Add Edit mode that allows directly overwriting hexadecimal values under the cursor. Toggle with `Shift+R` (switches from the traditional View mode). (#43)
 
 [go-inline-animation#6]: https://github.com/nyaosorg/go-inline-animation/pull/6
 [go-inline-animation#7]: https://github.com/nyaosorg/go-inline-animation/pull/7

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -1,5 +1,5 @@
 Changelog
-=============
+=========
 
 - GNU Make なしでビルドした場合に、バージョン文字列が空になってしまう問題を修正  
   今後、バージョンアップ時に `make bump` を実行する (#33)
@@ -8,6 +8,7 @@ Changelog
 - 保存に時間がかかった時、テキストアニメの消去位置が狂う問題を修正 ([go-inline-animation#6], [go-inline-animation#7], #36)
 - 上書き確認時に、READONLY 属性のファイルであることを明示するようにした (#37)
 - 上書き保存時に元ファイルのパーミッションが維持されない問題を修正 (#37,#42)
+- カーソル上の16進数を直接書き換える Editモード を追加。従来のモード（Viewモード）と `Shift+R` で切り替えるようにした (#43)
 
 [go-inline-animation#6]: https://github.com/nyaosorg/go-inline-animation/pull/6
 [go-inline-animation#7]: https://github.com/nyaosorg/go-inline-animation/pull/7

--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ or
 $ cat FILE | bine
 ```
 
+Modes
+-----
+
+The editor has two modes: View mode and Edit mode.
+
+* View mode (default)
+    * The file can be navigated safely without modifying data.
+    * Most keys are interpreted as commands.
+* Edit mode
+    * Hexadecimal digits (`0-9`, `a-f`) directly modify the byte under the cursor.
+    * The first digit replaces the high nibble and the second digit replaces the low nibble.
+    * After two digits are entered, the cursor moves to the next byte.
+
+Most command keys work in both modes.  
+In Edit mode, only hexadecimal digits (`0-9`, `a-f`) are interpreted as data input.
+Press `R` to toggle between View mode and Edit mode.
+
 Key-binding
 -----------
 
@@ -109,18 +126,23 @@ Key-binding
     * Move the cursor right
 * `0` (zero), `^`, `Ctrl-A`  
     * Move the cursor to the beginning of the current line
+    * `0` is available in View mode only
 * `$`, `Ctrl-E`  
     * Move the cursor to the end of the current line
 * `<`  
     * Move the cursor to the beginning of the file
 * `>`, `G`  
     * Move the cursor to the end of the file
-* `r`  
+* `r`
     * Replace the byte under the cursor
+* `R`
+    * Toggle between View mode and Edit mode
+    * In Edit mode, hexadecimal digits (`0-9`, `a-f`) overwrite the byte under the cursor
 * `i`  
     * Insert data (e.g., `0xFF`, `U+0000`, `"string"`)
 * `a`  
     * Append data (e.g., `0xFF`, `U+0000`, `"string"`)
+    * Available in View mode only
 * `x`, `DEL`  
     * Delete and yank the byte under the cursor
 * `p`  

--- a/keyfunc.go
+++ b/keyfunc.go
@@ -391,6 +391,38 @@ func keyFuncUndo(app *Application) error {
 	return nil
 }
 
+func keyFuncReplaceInline(app *Application, n byte) error {
+	address := app.cursor.Address()
+	orgValue := app.cursor.Value()
+	orgDirty := app.dirty
+
+	if app.editMode == editUpperMode {
+		app.cursor.SetValue((orgValue &^ 0xF0) | (n << 4))
+		app.editMode = editLowerMode
+	} else {
+		app.cursor.SetValue((orgValue &^ 0x0F) | (n & 0xF))
+		app.editMode = editUpperMode
+		app.cursor.Next()
+	}
+	undo := func(ap *Application) {
+		p := large.NewPointerAt(address, ap.buffer)
+		p.SetValue(orgValue)
+		ap.dirty = orgDirty
+	}
+	app.undoFuncs = append(app.undoFuncs, undo)
+	app.dirty = true
+	return nil
+}
+
+func keyFuncChangeMode(app *Application) error {
+	if app.editMode == viewMode {
+		app.editMode = editUpperMode
+	} else {
+		app.editMode = viewMode
+	}
+	return nil
+}
+
 var jumpTable = map[string]func(this *Application) error{
 	"u":         keyFuncUndo,
 	"i":         keyFuncInsertExp,
@@ -430,4 +462,5 @@ var jumpTable = map[string]func(this *Application) error{
 	"w":         keyFuncWriteFile,
 	"r":         keyFuncReplaceByte,
 	_KEY_CTRL_L: keyFuncRepaint,
+	"R":         keyFuncChangeMode,
 }

--- a/main.go
+++ b/main.go
@@ -66,31 +66,56 @@ const (
 	_RIGHTWARDS_TRIANGLE_HEADED_ARROW_TO_BAR = '\u2B72' // ->|
 )
 
+func makeHexOne(pointer *large.Pointer, cursorAddress int64, m editModeType, out *strings.Builder) {
+	value := pointer.Value()
+	var on, off string
+	i := pointer.Address() % 16
+	if ((i >> 2) & 1) == 0 {
+		on = _CELL1_COLOR_ON
+		off = _CELL1_COLOR_OFF
+	} else {
+		on = _CELL2_COLOR_ON
+		off = _CELL2_COLOR_OFF
+	}
+	if pointer.Address() == cursorAddress {
+		if m == editUpperMode {
+			fmt.Fprintf(out, "%s%1X%s%s%1X%s",
+				_CURSOR_COLOR_ON,
+				(value>>4)&15,
+				_CURSOR_COLOR_OFF,
+				on,
+				value&15,
+				off)
+			return
+		} else if m == editLowerMode {
+			fmt.Fprintf(out, "%s%1X%s%s%1X%s",
+				on,
+				(value>>4)&15,
+				off,
+				_CURSOR_COLOR_ON,
+				value&15,
+				_CURSOR_COLOR_OFF)
+			return
+		}
+		on = _CURSOR_COLOR_ON
+		off = _CURSOR_COLOR_OFF
+	}
+	fmt.Fprintf(out, "%s%02X%s", on, value, off)
+}
+
 // See. en.wikipedia.org/wiki/Unicode_control_characters#Control_pictures
 
-func makeHexPart(pointer *large.Pointer, cursorAddress int64, out *strings.Builder) bool {
+func makeHexPart(pointer *large.Pointer, cursorAddress int64, mode editModeType, out *strings.Builder) bool {
 	fmt.Fprintf(out, "%s%08X%s ", _CELL2_COLOR_ON, pointer.Address(), _CELL2_COLOR_OFF)
-	var fieldSeperator string
 	for i := 0; i < LINE_SIZE; i++ {
-		var on, off string
-		if pointer.Address() == cursorAddress {
-			on = _CURSOR_COLOR_ON
-			off = _CURSOR_COLOR_OFF
-		} else if ((i >> 2) & 1) == 0 {
-			on = _CELL1_COLOR_ON
-			off = _CELL1_COLOR_OFF
-		} else {
-			on = _CELL2_COLOR_ON
-			off = _CELL2_COLOR_OFF
-		}
-		fmt.Fprintf(out, "%s%s%02X%s", fieldSeperator, on, pointer.Value(), off)
+		makeHexOne(pointer, cursorAddress, mode, out)
 		if err := pointer.Next(); err != nil {
 			for ; i < LINE_SIZE-1; i++ {
 				out.WriteString("   ")
 			}
 			return false
 		}
-		fieldSeperator = " "
+		out.WriteByte(' ')
 	}
 	return true
 }
@@ -156,7 +181,7 @@ func makeAsciiPart(enc encoding.Encoding, pointer *large.Pointer, cursorAddress 
 	return true
 }
 
-func makeLineImage(enc encoding.Encoding, pointer *large.Pointer, cursorAddress int64) (string, bool) {
+func makeLineImage(enc encoding.Encoding, pointer *large.Pointer, cursorAddress int64, mode editModeType) (string, bool) {
 	var out strings.Builder
 	off := ""
 	if p := pointer.Address(); p <= cursorAddress && cursorAddress < p+LINE_SIZE {
@@ -165,8 +190,7 @@ func makeLineImage(enc encoding.Encoding, pointer *large.Pointer, cursorAddress 
 	}
 
 	asciiPointer := *pointer
-	hasNextLine := makeHexPart(pointer, cursorAddress, &out)
-	out.WriteByte(' ')
+	hasNextLine := makeHexPart(pointer, cursorAddress, mode, &out)
 	makeAsciiPart(enc, &asciiPointer, cursorAddress, &out)
 
 	out.WriteString(_ANSI_ERASE_LINE)
@@ -182,7 +206,7 @@ func (app *Application) View() (int, error) {
 	cursor := app.window.Clone()
 	cursorAddress := app.cursor.Address()
 	for {
-		line, cont := makeLineImage(app.encoding, cursor, cursorAddress)
+		line, cont := makeLineImage(app.encoding, cursor, cursorAddress, app.editMode)
 
 		if f := app.cache[count]; f != line {
 			io.WriteString(out, line)
@@ -195,6 +219,14 @@ func (app *Application) View() (int, error) {
 		io.WriteString(out, "\r\n") // "\r" is for Linux and go-tty
 	}
 }
+
+type editModeType int
+
+const (
+	viewMode editModeType = iota
+	editUpperMode
+	editLowerMode
+)
 
 type Application struct {
 	tty1         ttyadapter.Tty
@@ -212,6 +244,7 @@ type Application struct {
 	cache        map[int]string
 	encoding     encoding.Encoding
 	undoFuncs    []func(app *Application)
+	editMode     editModeType
 }
 
 func (app *Application) dataHeight() int {
@@ -284,6 +317,11 @@ func (app *Application) printDefaultStatusBar() {
 		io.WriteString(app.out, "*")
 	} else {
 		io.WriteString(app.out, " ")
+	}
+	if app.editMode == viewMode {
+		io.WriteString(app.out, "View:")
+	} else {
+		io.WriteString(app.out, "Edit:")
 	}
 	fmt.Fprintf(app.out, "[%s]", app.encoding.ModeString())
 
@@ -429,11 +467,23 @@ func Run(args []string) error {
 			return err
 		}
 		app.message = ""
+
+		if app.editMode != viewMode {
+			if index := strings.Index("0123456789abcdef", ch); index >= 0 {
+				if err := keyFuncReplaceInline(app, byte(index)); err != nil {
+					return err
+				}
+				goto skip
+			} else {
+				app.editMode = editUpperMode
+			}
+		}
 		if hander, ok := jumpTable[ch]; ok {
 			if err := hander(app); err != nil {
 				return err
 			}
 		}
+	skip:
 		if app.buffer.Len() <= 0 {
 			return nil
 		}


### PR DESCRIPTION
(English)
- Add Edit mode that allows directly overwriting hexadecimal values under the cursor. Toggle with `Shift+R` (switches from the traditional View mode).

(Japanese)
- カーソル上の16進数を直接書き換える Editモード を追加。従来のモード（Viewモード）と `Shift+R` で切り替えるようにした
