### PR TITLE
Refactor `editModeType` to use interface instead of constants

### DIFF
--- a/keyfunc.go
+++ b/keyfunc.go
@@ -51,13 +51,10 @@ func keyFuncNext(this *Application) error {
 
 // keyFuncBackword move the cursor to the previous byte.
 func keyFuncBackword(app *Application) error {
-	if app.editMode == editLowerMode {
-		app.editMode = editUpperMode
-		return nil
-	} else if app.editMode == editUpperMode {
-		app.editMode = editLowerMode
+	var ok bool
+	if app.editMode, ok = app.editMode.Prev(); ok {
+		app.cursor.Prev()
 	}
-	app.cursor.Prev()
 	return nil
 }
 
@@ -91,12 +88,8 @@ func keyFuncQuit(this *Application) error {
 
 // keyFuncForward moves the cursor to the next one byte.
 func keyFuncForward(app *Application) error {
-	if app.editMode == editUpperMode {
-		app.editMode = editLowerMode
-	} else if app.editMode == editLowerMode {
-		app.cursor.Next()
-		app.editMode = editUpperMode
-	} else {
+	var ok bool
+	if app.editMode, ok = app.editMode.Next(); ok {
 		app.cursor.Next()
 	}
 	return nil
@@ -108,9 +101,7 @@ func keyFuncGoBeginOfLine(app *Application) error {
 	if n > 0 {
 		app.cursor.Rewind(n)
 	}
-	if app.editMode == editLowerMode {
-		app.editMode = editUpperMode
-	}
+	app.editMode = app.editMode.Reset()
 	return nil
 }
 
@@ -120,27 +111,21 @@ func keyFuncGoEndOfLine(app *Application) error {
 	if n > 0 {
 		app.cursor.Skip(n)
 	}
-	if app.editMode == editLowerMode {
-		app.editMode = editUpperMode
-	}
+	app.editMode = app.editMode.Reset()
 	return nil
 }
 
 func keyFuncGoBeginOfFile(app *Application) error {
 	app.cursor = large.NewPointer(app.buffer)
 	app.window = large.NewPointer(app.buffer)
-	if app.editMode == editLowerMode {
-		app.editMode = editUpperMode
-	}
+	app.editMode = app.editMode.Reset()
 	return nil
 }
 
 // keyFuncGoEndOfFile moves the cursor to the end of the file.
 func keyFuncGoEndOfFile(app *Application) error {
 	app.cursor.GoEndOfFile()
-	if app.editMode == editLowerMode {
-		app.editMode = editUpperMode
-	}
+	app.editMode = app.editMode.Reset()
 	return nil
 }
 
@@ -421,12 +406,13 @@ func keyFuncReplaceInline(app *Application, n byte) error {
 	orgValue := app.cursor.Value()
 	orgDirty := app.dirty
 
-	if app.editMode == editUpperMode {
-		app.cursor.SetValue((orgValue &^ 0xF0) | (n << 4))
-		app.editMode = editLowerMode
-	} else {
+	if app.editMode.(directMode).Lower {
 		app.cursor.SetValue((orgValue &^ 0x0F) | (n & 0xF))
-		app.editMode = editUpperMode
+	} else {
+		app.cursor.SetValue((orgValue &^ 0xF0) | (n << 4))
+	}
+	var ok bool
+	if app.editMode, ok = app.editMode.Next(); ok {
 		app.cursor.Next()
 	}
 	undo := func(ap *Application) {
@@ -440,10 +426,10 @@ func keyFuncReplaceInline(app *Application, n byte) error {
 }
 
 func keyFuncChangeMode(app *Application) error {
-	if app.editMode == viewMode {
-		app.editMode = editUpperMode
+	if _, ok := app.editMode.(directMode); ok {
+		app.editMode = viewMode{}
 	} else {
-		app.editMode = viewMode
+		app.editMode = directMode{}
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -78,29 +78,10 @@ func makeHexOne(pointer *large.Pointer, cursorAddress int64, m editModeType, out
 		off = _CELL2_COLOR_OFF
 	}
 	if pointer.Address() == cursorAddress {
-		if m == editUpperMode {
-			fmt.Fprintf(out, "%s%1X%s%s%1X%s",
-				_CURSOR_COLOR_ON,
-				(value>>4)&15,
-				_CURSOR_COLOR_OFF,
-				on,
-				value&15,
-				off)
-			return
-		} else if m == editLowerMode {
-			fmt.Fprintf(out, "%s%1X%s%s%1X%s",
-				on,
-				(value>>4)&15,
-				off,
-				_CURSOR_COLOR_ON,
-				value&15,
-				_CURSOR_COLOR_OFF)
-			return
-		}
-		on = _CURSOR_COLOR_ON
-		off = _CURSOR_COLOR_OFF
+		m.PrintByte(value, on, off, out)
+	} else {
+		fmt.Fprintf(out, "%s%02X%s", on, value, off)
 	}
-	fmt.Fprintf(out, "%s%02X%s", on, value, off)
 }
 
 // See. en.wikipedia.org/wiki/Unicode_control_characters#Control_pictures
@@ -220,14 +201,6 @@ func (app *Application) View() (int, error) {
 	}
 }
 
-type editModeType int
-
-const (
-	viewMode editModeType = iota
-	editUpperMode
-	editLowerMode
-)
-
 type Application struct {
 	tty1         ttyadapter.Tty
 	in           io.Reader
@@ -273,6 +246,7 @@ func NewApplication(tty ttyadapter.Tty, in io.Reader, out io.Writer, defaultName
 		out:       out,
 		buffer:    large.NewBuffer(in),
 		clipBoard: NewClip(),
+		editMode:  viewMode{},
 	}
 	this.window = large.NewPointer(this.buffer)
 	if this.window == nil {
@@ -318,11 +292,7 @@ func (app *Application) printDefaultStatusBar() {
 	} else {
 		io.WriteString(app.out, " ")
 	}
-	if app.editMode == viewMode {
-		io.WriteString(app.out, "View:")
-	} else {
-		io.WriteString(app.out, "Edit:")
-	}
+	io.WriteString(app.out, app.editMode.String())
 	fmt.Fprintf(app.out, "[%s]", app.encoding.ModeString())
 
 	fmt.Fprintf(app.out, "%4[1]d='\\x%02[1]X'", app.cursor.Value())
@@ -468,20 +438,10 @@ func Run(args []string) error {
 		}
 		app.message = ""
 
-		if app.editMode != viewMode {
-			if index := strings.Index("0123456789abcdef", ch); index >= 0 {
-				if err := keyFuncReplaceInline(app, byte(index)); err != nil {
-					return err
-				}
-				goto skip
-			}
+		if err := app.editMode.Handle(ch, app); err != nil {
+			return err
 		}
-		if hander, ok := jumpTable[ch]; ok {
-			if err := hander(app); err != nil {
-				return err
-			}
-		}
-	skip:
+
 		if app.buffer.Len() <= 0 {
 			return nil
 		}

--- a/mode.go
+++ b/mode.go
@@ -1,0 +1,100 @@
+package bine
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type editModeType interface {
+	Handle(string, *Application) error
+	String() string
+	PrintByte(value byte, on, off string, w io.Writer)
+	Reset() editModeType
+	Next() (editModeType, bool)
+	Prev() (editModeType, bool)
+}
+
+type viewMode struct{}
+
+func (viewMode) Handle(ch string, app *Application) error {
+	if hander, ok := jumpTable[ch]; ok {
+		return hander(app)
+	}
+	return nil
+}
+
+func (viewMode) String() string {
+	return "Command:"
+}
+
+func (d viewMode) PrintByte(value byte, on, off string, w io.Writer) {
+	fmt.Fprintf(w, "%s%02X%s", _CURSOR_COLOR_ON, value, _CURSOR_COLOR_OFF)
+}
+
+func (viewMode) Reset() editModeType {
+	return viewMode{}
+}
+
+func (viewMode) Next() (_ editModeType, moveNextByte bool) {
+	return viewMode{}, true
+}
+
+func (viewMode) Prev() (_ editModeType, movePrevByte bool) {
+	return viewMode{}, true
+}
+
+type directMode struct {
+	Lower bool
+}
+
+func (directMode) Handle(ch string, app *Application) error {
+	if index := strings.Index("0123456789abcdef", ch); index >= 0 {
+		return keyFuncReplaceInline(app, byte(index))
+	}
+	return viewMode{}.Handle(ch, app)
+}
+
+func (directMode) String() string {
+	return "Direct:"
+}
+
+func (d directMode) PrintByte(value byte, on, off string, w io.Writer) {
+	upper := (value >> 4) & 15
+	lower := value & 15
+	if d.Lower {
+		fmt.Fprintf(w, "%s%1X%s%s%1X%s",
+			on,
+			upper,
+			off,
+			_CURSOR_COLOR_ON,
+			lower,
+			_CURSOR_COLOR_OFF)
+	} else {
+		fmt.Fprintf(w, "%s%1X%s%s%1X%s",
+			_CURSOR_COLOR_ON,
+			upper,
+			_CURSOR_COLOR_OFF,
+			on,
+			lower,
+			off)
+	}
+}
+
+func (directMode) Reset() editModeType {
+	return directMode{}
+}
+
+func (d directMode) Next() (_ editModeType, moveNextByte bool) {
+	if d.Lower {
+		return directMode{Lower: false}, true
+	}
+	return directMode{Lower: true}, false
+}
+
+func (d directMode) Prev() (_ editModeType, movePrevByte bool) {
+	if d.Lower {
+		return directMode{Lower: false}, false
+	}
+	return directMode{Lower: true}, true
+}


### PR DESCRIPTION
## From
```go
type editModeType int
const (
	viewMode editModeType = iota
	editUpperMode
	editLowerMode
)
```
## To
```go
type editModeType interface {
	Handle(string, *Application) error
	String() string
	PrintByte(value byte, on, off string, w io.Writer)
	Reset() editModeType
	Next() (editModeType, bool)
	Prev() (editModeType, bool)
}
```