### PR TITLE
Fix display corruption when opening files larger than about 40 bytes

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,8 +201,9 @@ func (app *Application) makeLineImage(pointer *large.Pointer) (string, bool) {
 		off = _ANSI_UNDERLINE_OFF
 	}
 
-	hasNextLine := app.makeHexPart(pointer.Clone(), &out)
-	app.makeAsciiPart(pointer, &out)
+	asciiPointer := pointer.Clone()
+	hasNextLine := app.makeHexPart(pointer, &out)
+	app.makeAsciiPart(asciiPointer, &out)
 
 	out.WriteString(_ANSI_ERASE_LINE)
 	out.WriteString(off)


### PR DESCRIPTION
(English)
- Fix display corruption when opening files larger than about 40 bytes (regression in [#66]).

(Japanese)
- 40バイト以上のデータを開くと、画面に同じ行が繰り返し表示されたり、カーソル行を示す下線が何回も表示されたりする不具合を修正 （[#66] で余計なことをしてエンバグした模様）

[#66]: https://github.com/hymkor/bine/pull/66